### PR TITLE
[TOOL-1440] Fix UI issues pointed out in the UX review

### DIFF
--- a/src/cm.css
+++ b/src/cm.css
@@ -12,7 +12,7 @@
   --neue-haas-regular: 300;
   /* Neue Haas weights */
   --title-neue-haas-weight: 500;
-  --primary-button-neue-haas-weight: 400;
+  --primary-button-neue-haas-weight: 500;
   /* Rethink Sans weights */
   --title-rethink-sans-weight: 700;
   --primary-button-rethink-sans-weight: 700;
@@ -41,7 +41,7 @@
 }
 
 .privacy-policy-bottom {
-  padding-top: 25px;
+  margin-bottom: 32px;
 }
 
 .container-confirm-privacy-link {
@@ -580,7 +580,7 @@ a:focus {
   position: relative;
   bottom: 10px;
   margin: 0 auto;
-  width: calc(100% - 10px);
+  width: calc(100% - 20px);
   box-sizing: border-box;
   border-radius: 0px;
   border: 2px solid #000000;
@@ -891,6 +891,11 @@ a:focus {
 .transcend-logo-svg .transcend-wordmark {
   fill-opacity: 0;
   transition: fill 150ms, fill-opacity 150ms;
+}
+
+.text-title-left {
+  margin: 0 18px 0 0;
+  text-align: left;
 }
 
 /*******************

--- a/src/cm.css
+++ b/src/cm.css
@@ -11,14 +11,14 @@
   --neue-haas-bold: 600;
   --neue-haas-regular: 300;
   /* Neue Haas weights */
-  --title-neue-haas-weight: 500;
-  --primary-button-neue-haas-weight: 500;
+  --title-neue-haas-weight: 700;
+  --primary-button-neue-haas-weight: 600;
   /* Rethink Sans weights */
   --title-rethink-sans-weight: 700;
   --primary-button-rethink-sans-weight: 700;
   /* change these to neue-haas for app & portal css */
-  --title-text-weight: var(--title-rethink-sans-weight);
-  --primary-button-weight: var(--primary-button-rethink-sans-weight);
+  --title-text-weight: var(--title-neue-haas-weight);
+  --primary-button-weight: var(--primary-button-neue-haas-weight);
 }
 
 .background-blur {

--- a/src/components/CompleteOptions.tsx
+++ b/src/components/CompleteOptions.tsx
@@ -123,6 +123,11 @@ export function CompleteOptions({
             />
           ))}
           </div>
+          <div class="privacy-policy-bottom">
+            <a href="https://privacy.goshippo.com/policies?name=privacy-notice" class="privacy-policy-link" target="_blank" rel="noreferrer">
+              {formatMessage(bottomMenuMessages.showPolicyButtonAcceptOrRejectAllOrMoreChoices)}
+            </a>
+        </div>
           <div className='container-confirm-privacy-link'>
           <div className="button-confirm-cta">
           <Button
@@ -132,11 +137,6 @@ export function CompleteOptions({
             {...(orderedSelections.length === 0 ? { initialFocus: true } : {})}
           />
           </div>
-          <div class="privacy-policy-bottom">
-            <a href="https://privacy.goshippo.com/policies?name=privacy-notice" class="privacy-policy-link" target="_blank" rel="noreferrer">
-              {formatMessage(bottomMenuMessages.showPolicyButtonAcceptOrRejectAllOrMoreChoices)}
-            </a>
-        </div>
         </div>
       </form>
     </div>

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -100,7 +100,7 @@ export const messages = defineMessages('ui.src.messages', {
     description: 'Button to dismiss privacy policy notice.',
   },
   doNotSellOptedOut: {
-    defaultMessage: `Successfully opted out.`,
+    defaultMessage: 'Successfully opted out',
     description:
       'Explainer text in DoNotSellExplainer banner when opted out of sale of data.',
   },
@@ -113,7 +113,7 @@ export const messages = defineMessages('ui.src.messages', {
     description: 'An accessible label for the button to switch language',
   },
   doNotSellOptedIn: {
-    defaultMessage: `Switch the toggle to opt out.`,
+    defaultMessage: 'Switch the toggle to opt out',
     description:
       'Explainer text in DoNotSellExplainer banner when opted in to sale of data.',
   },


### PR DESCRIPTION
Desktop - Remove period at the end of the Successfully Opt Out.

 
![Screen Cast 2024-09-17 at 10 46 48 AM](https://github.com/user-attachments/assets/17d6c275-3bad-4ca9-ae39-180274100c4d)


Mobile Desktop
    Left align all content in the mobile
    In the EU/UK version move the "See our Privacy Notice" above the CTA (Confirm button)
    Mobile in EU/UK should also be left justified
   The goal is to make the left and right margins a bit further from the edge of the device.  If this messes up the experience or is difficult to do, it is not a deal breaker.
![Screen Shot 2024-09-17 at 10 44 26 AM](https://github.com/user-attachments/assets/a3cc45a6-5931-4aca-a5b4-9164056e98a2)

 

WebApp
    Make all the CTA (all three buttons) bold text
    Same padding consideration and same feedback to move the Privacy link above the CTA (Confirm Button)

![image](https://github.com/user-attachments/assets/92b7c238-43d2-4546-8546-9cd9edf953c9)
![image](https://github.com/user-attachments/assets/357f4127-aae2-4c6f-8e8e-6b9c0a6e6def)
